### PR TITLE
fix so that the nftcard doesn"t mistakenly appear

### DIFF
--- a/components/OnChainEvent.tsx
+++ b/components/OnChainEvent.tsx
@@ -139,10 +139,9 @@ export default function OnchainEvent({ txid }: {txid: string}) {
 
       const url = event.content.url || event.content
 
-      console.log(url)
 
       // Check if it's a RelayX item link
-      if (url.match('https://relayx.com/assets/' && nftItemData)) {
+      if (url.includes('https://relayx.com/assets/' && nftItemData?.data)) {
         return <NFTItemCard nft={nftItemData?.data} />
       }
 


### PR DESCRIPTION
`.match()` returns an array which was mistakenly making an NFTCard appear. Merging this in as well. 