### PR TITLE
fix: Add Low fund error to Composer for relayx.

### DIFF
--- a/components/Composer.tsx
+++ b/components/Composer.tsx
@@ -93,14 +93,26 @@ const Composer = () => {
             router.push(`/${resp.txid}`)
           } catch (error) {
             console.log(error)
-            toast('Error!', {
-              icon: '🐛',
-              style: {
-              borderRadius: '10px',
-              background: '#333',
-              color: '#fff',
-              },
+            if(stag.relayone!.errors.isLowFunds(error) {
+              toast('Error! Too Low Funds', {
+                icon: '🐛',
+                style: {
+                borderRadius: '10px',
+                background: '#333',
+                color: '#fff',
+                },
             });
+            }
+            else {
+              toast('Error!', {
+                icon: '🐛',
+                style: {
+                borderRadius: '10px',
+                background: '#333',
+                color: '#fff',
+                },
+              });
+            }
           }
           break;
         case "twetch":


### PR DESCRIPTION
I noticed when trying to use pow.co with an account that had less than 0.001 BSV that the message given when I tried to create a post, did not tell me the reason why, I had to check the console. This uses the relay one method from the API, as found https://docs.relayx.com/#/api?id=relayoneerrorsislowfundse-error-gt-promise here. Although the API says it returns a promise, the code itself. 
<img width="415" alt="Screenshot 2023-04-03 at 22 04 00" src="https://user-images.githubusercontent.com/690546/229627154-2fdcc3e3-05ef-478a-874c-4e87781f672e.png">
Shows it does not, so using in a simple if works.