### PR TITLE
fix: Add ErrorBoundary to cards.

### DIFF
--- a/components/CardErrorBoundary.tsx
+++ b/components/CardErrorBoundary.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+ interface CardErrorBoundaryProps {
+     children: React.ReactNode
+ }
+
+ interface CardErrorBoundaryState {
+     hasError: boolean
+ }
+
+ class CardErrorBoundary extends React.Component<CardErrorBoundaryProps, CardErrorBoundaryState> {
+     constructor(props:CardErrorBoundaryProps) {
+     super(props);
+     this.state = { hasError: false };
+   }
+   static getDerivedStateFromError(error: any) {
+     return { hasError: true };
+   }
+   componentDidCatch(error: any, errorInfo: any) {
+     console.log({ error, errorInfo });
+   }
+   render() {
+     if (this.state.hasError) {
+       return (
+          <div  className='flex content-center bg-primary-100 dark:bg-primary-600/20 hover:sm:bg-primary-200 hover:dark:sm:bg-primary-500/20 mt-0.5 first:md:rounded-t-lg last:md:rounded-b-lg h-32'>
+           <div className={``}>
+                         <div className='mt-1 text-gray-900 dark:text-white text-base leading-6 whitespace-pre-line break-words'>
+                         <h2>Oops, there is an error!</h2>
+                         </div>
+             <div>
+           <button
+             type="button"
+             onClick={() => this.setState({ hasError: false })}
+           >
+             Try again?
+           </button>
+           </div>
+           </div>
+         </div>
+       )
+     }
+     return this.props.children;
+ }
+ }
+
+ export default CardErrorBoundary;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -10,7 +10,7 @@ import { FormattedMessage } from "react-intl"
 import BitcoinBrowser from "../components/BitcoinBrowser"
 import FindOrCreate from "../components/FindOrCreate"
 import { useBitcoin } from "../context/BitcoinContext"
-
+import CardErrorBoundary from "../components/CardErrorBoundary"
 
 
 
@@ -58,7 +58,11 @@ export default function Home() {
       <div className="col-span-12 lg:col-span-6 min-h-screen">
         <div className="mt-5 lg:mt-10 mb-[200px]">
           {loading ? <Loader/> : rankings?.map((post: Ranking) => {
-            return <BoostContentCard key={post.content_txid} {...post}/>
+            return (
+             <CardErrorBoundary key={post.content_txid}>
+               <BoostContentCard  {...post}/>
+               </CardErrorBoundary>
+             )
           } ) }
         </div>
       </div>


### PR DESCRIPTION
This prevents a single failing card from crashing the entire page.