### PR TITLE
Fix errors related to 'staging-relayx' endpoint being called incorrectly/unneccesarily

### DIFF
--- a/components/OnChainEvent.tsx
+++ b/components/OnChainEvent.tsx
@@ -1,184 +1,237 @@
+import useSWR from "swr";
 
-import useSWR from 'swr'
+import {
+  YoutubeMetadataOnchain,
+  youtubePlayerOpts,
+} from "./YoutubeMetadataOnchain";
 
-import { YoutubeMetadataOnchain, youtubePlayerOpts } from "./YoutubeMetadataOnchain"
-
-import { LinkPreview } from '@dhaiwat10/react-link-preview';
-import axios from 'axios';
-import { fetcher } from '../hooks/useAPI'
-import PowcoDevIssue from './PowcoDevIssue';
-import NFTCard from './NFTCard';
+import { LinkPreview } from "@dhaiwat10/react-link-preview";
+import axios from "axios";
+import { fetcher } from "../hooks/useAPI";
+import PowcoDevIssue from "./PowcoDevIssue";
+import NFTCard from "./NFTCard";
 import Gist from "react-gist";
-import PostDescription from './PostDescription';
-import { useTheme } from 'next-themes';
-import YouTube from 'react-youtube';
-import NFTItemCard from './NFTItemCard';
-import { TwitterTweetEmbed } from 'react-twitter-embed';
+import PostDescription from "./PostDescription";
+import { useTheme } from "next-themes";
+import YouTube from "react-youtube";
+import NFTItemCard from "./NFTItemCard";
+import { TwitterTweetEmbed } from "react-twitter-embed";
+import { isRelayX } from "../utils/relayX";
 
 const customFetcher = async (url: string) => {
-    const response = await fetch(`https://link-preview-proxy.pow.co/v2?url=${url}`);
-    const json = await response.json();
-    return json.metadata;
+  const response = await fetch(
+    `https://link-preview-proxy.pow.co/v2?url=${url}`
+  );
+  const json = await response.json();
+  return json.metadata;
 };
 
-export default function OnchainEvent({ txid }: {txid: string}) {
-    const theme = useTheme()
+export default function OnchainEvent({ txid }: { txid: string }) {
+  const theme = useTheme();
 
-    // @ts-ignore
-    const { data, isLoading } = useSWR(`https://onchain.sv/api/v1/events/${txid}`, fetcher) // TODO remove this data fetch and take data from higher in the app
+  // @ts-ignore
+  const { data, isLoading } = useSWR(
+    `https://onchain.sv/api/v1/events/${txid}`,
+    fetcher
+  ); // TODO remove this data fetch and take data from higher in the app
 
-    if (data) {
-      var [event] = data.events
+  if (data) {
+    var [event] = data.events;
+  }
+
+  // Check if the event is a RelayX Marketplace Link and fetch the NFT data
+  const relayXData = isRelayX(event?.content?.url);
+  // Conditionally fetch
+  const { data: nftData } = useSWR(
+    relayXData && !relayXData.itemLocation
+      ? `https://staging-backend.relayx.com/api/market/${relayXData.marketLocation}`
+      : null,
+    fetcher
+  );
+
+  const { data: nftItemData } = useSWR(
+    relayXData && relayXData.itemLocation
+      ? `https://staging-backend.relayx.com/api/market/${relayXData.marketLocation}/items/${relayXData.itemLocation}`
+      : null,
+    fetcher
+  );
+
+  if (isLoading) {
+    return (
+      <div className="">
+        <div role="status" className="max-w-sm animate-pulse">
+          <div className="h-2.5 bg-gray-300 rounded-full dark:bg-gray-700 w-48 mb-4"></div>
+          <div className="h-2 bg-gray-300 rounded-full dark:bg-gray-700 max-w-[360px] mb-2.5"></div>
+          <div className="h-2 bg-gray-300 rounded-full dark:bg-gray-700 mb-2.5"></div>
+          <div className="h-2 bg-gray-300 rounded-full dark:bg-gray-700 max-w-[330px] mb-2.5"></div>
+          <div className="h-2 bg-gray-300 rounded-full dark:bg-gray-700 max-w-[300px] mb-2.5"></div>
+          <div className="h-2 bg-gray-300 rounded-full dark:bg-gray-700 max-w-[360px]"></div>
+          <span className="sr-only">Loading...</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (!data || data.events.length === 0) {
+    return <></>;
+  }
+
+  // Render RelayX MarketPlace Events
+  if (relayXData && !relayXData.itemLocation) {
+    const nft = nftData?.data?.token;
+    if (nft) {
+      return <NFTCard nft={nft} />;
     }
+  }
 
-    const marketId = event?.content?.url?.split('/')[4]
-    const itemId = event?.content?.url?.split('/')[5]
+  // Render RelayX Item Events
+  if (relayXData && relayXData.itemLocation) {
+    return <NFTItemCard nft={nftItemData?.data} />;
+  }
 
-    // Check if the event is a RelayX Marketplace Link and fetch the NFT data
-    const relayItemOrigin = event?.content?.url?.split('/').pop()
-    // Conditionally fetch
-    const {data: nftData} =  useSWR(relayItemOrigin ? `https://staging-backend.relayx.com/api/market/${relayItemOrigin}` : null, fetcher)
-    const {data: nftItemData} =  useSWR(marketId ? `https://staging-backend.relayx.com/api/market/${marketId}/items/${itemId}`: null, fetcher)
+  if (event?.content?.url?.startsWith("https://twitter.com/")) {
+    const tweetId = event.content.url.split("/").pop();
+    return <TwitterTweetEmbed tweetId={tweetId} />;
+  }
 
-    if (isLoading){
-      return (
-          <div className=''>
-              <div role="status" className="max-w-sm animate-pulse">
-                  <div className="h-2.5 bg-gray-300 rounded-full dark:bg-gray-700 w-48 mb-4"></div>
-                  <div className="h-2 bg-gray-300 rounded-full dark:bg-gray-700 max-w-[360px] mb-2.5"></div>
-                  <div className="h-2 bg-gray-300 rounded-full dark:bg-gray-700 mb-2.5"></div>
-                  <div className="h-2 bg-gray-300 rounded-full dark:bg-gray-700 max-w-[330px] mb-2.5"></div>
-                  <div className="h-2 bg-gray-300 rounded-full dark:bg-gray-700 max-w-[300px] mb-2.5"></div>
-                  <div className="h-2 bg-gray-300 rounded-full dark:bg-gray-700 max-w-[360px]"></div>
-                  <span className="sr-only">Loading...</span>
-              </div>
-          </div>
-      )
+  if (event.app === "powstream.com") {
+    if (
+      event.type === "youtube_video_metadata" &&
+      event.author === "1D1hSyDc7UF4KbGFTSSXLirCBepjcN19GN"
+    ) {
+      return <YoutubeMetadataOnchain txid={txid} event={event} />;
     }
+  }
 
-    if (!data || data.events.length === 0) {
-      return <></>
-    }
-
-    // Render RelayX MarketPlace Events
-    if (event?.content?.url?.startsWith('https://relayx.com/market/' && nftData)) {
-      const nft = nftData?.data?.token
-      if (nft) {
-        return <NFTCard nft={nft}/>
-      }
-    }
-
-    if(event?.content?.url?.startsWith('https://twitter.com/')) {
-      const tweetId = event.content.url.split('/').pop()
-        return  <TwitterTweetEmbed
-          tweetId={tweetId}
-        />
-    }
-
-    if (event.app === 'powstream.com') {
-
-      if (event.type === 'youtube_video_metadata' && event.author === '1D1hSyDc7UF4KbGFTSSXLirCBepjcN19GN') {
-
-        return <YoutubeMetadataOnchain txid={txid} event={event}/>
-
-      }
-    }
-
-    if (event.app === 'egoboost.vip') {
-
-      return <>
-      <h3><a className="egoboost-link" href={`https://egoboost.vip`}>EgoBoost.VIP</a></h3>
-
-      <h3>Paymail: {event.content?.paymail}</h3>
-    </>
-    }
-
-    if (event.app === '1HWaEAD5TXC2fWHDiua9Vue3Mf8V1ZmakN') { // askbitcoin.ai
-
-      if (event.type === 'question') {
-
-        return <>
-          <h3><a className="text-xl font-semibold hover:underline " href={`https://askbitcoin.ai/questions/${event.txid}`}>AskBitcoin.AI Question:</a></h3>
-
-          <PostDescription bContent={event.content.content}/>
-        </>
-      }
-
-      if (event.type === 'answer') {
-
-        return <>
-          <h3><a className="text-xl font-semibold hover:underline " href={`https://askbitcoin.ai/answers/${event.txid}`}>AskBitcoin.AI Answer:</a></h3>
-          <PostDescription bContent={event.content.content}/>
-        </>
-      }
-
-    }
-
-    if (event.app === 'boostpatriots.win' && event.author === "18h6yhKBBqXQge6XRauMTeEaQ9HF4jR1qV") {
-
-      return <>
-        <h3><a rel="noreferrer"  href={`https://boostpatriots.win${event.content.href}`}>BoostPatriots.Win</a></h3>
-        <h4>{event.content.title}</h4>
-      </>
-    }
-
-    if (event.app === 'powco.dev' && event.type === 'github.issue') {
-
-      return <PowcoDevIssue event={event} />
-
-
-    }
-
-    if (event.type === 'url') {
-
-      if (event.content.url.match('https://gist.github.com')) {
-
-        const id = event.content.url.split('/').pop()
-
-        return <>
-              <small className=''><a href='{event.content.html_url}' className='blankLink'>{event.content.url}</a></small>
-                <div className='text-ellipsis '>
-                    <Gist  id={id} />
-                </div>
-
-        </>
-
-      }
-
-      const url = event.content.url || event.content
-
-
-      // Check if it's a RelayX item link
-      if (url.includes('https://relayx.com/assets/' && nftItemData?.data)) {
-        return <NFTItemCard nft={nftItemData?.data} />
-      }
-
-      // 1. check if url is youtube
-      const youtubeLinkRegex = /^(?:https?:\/\/)?(?:www\.)?(?:m\.)?(?:youtu\.be\/|youtube\.com\/(?:embed\/|v\/|watch\?v=|watch\?.+&v=))((\w|-){11})(?:\S+)?$/;
-
-      const youtubeMatch = youtubeLinkRegex.exec(url)
-      if(youtubeMatch){
-        // 2. get the youtube video id
-        const videoId = youtubeMatch[1]
-        return <YouTube videoId={videoId} opts={youtubePlayerOpts}/>
-      } else {
-        return <>
-        <LinkPreview  url={url} fetcher={customFetcher}  showLoader showPlaceholderIfNoImage
-        fallback={<>
-          <a onClick={(e:any) => e.stopPropagation()} target='_blank' rel='noreferrer' href={url} className='cursor-pointer text-ellipsis break-words text-blue-500 hover:underline'>{url}</a>
-        </>}
-         />
-
-      </>
-
-      }
-
-
-    }
-
+  if (event.app === "egoboost.vip") {
     return (
       <>
-      </>
-    )
+        <h3>
+          <a className="egoboost-link" href={`https://egoboost.vip`}>
+            EgoBoost.VIP
+          </a>
+        </h3>
 
+        <h3>Paymail: {event.content?.paymail}</h3>
+      </>
+    );
   }
+
+  if (event.app === "1HWaEAD5TXC2fWHDiua9Vue3Mf8V1ZmakN") {
+    // askbitcoin.ai
+
+    if (event.type === "question") {
+      return (
+        <>
+          <h3>
+            <a
+              className="text-xl font-semibold hover:underline "
+              href={`https://askbitcoin.ai/questions/${event.txid}`}
+            >
+              AskBitcoin.AI Question:
+            </a>
+          </h3>
+
+          <PostDescription bContent={event.content.content} />
+        </>
+      );
+    }
+
+    if (event.type === "answer") {
+      return (
+        <>
+          <h3>
+            <a
+              className="text-xl font-semibold hover:underline "
+              href={`https://askbitcoin.ai/answers/${event.txid}`}
+            >
+              AskBitcoin.AI Answer:
+            </a>
+          </h3>
+          <PostDescription bContent={event.content.content} />
+        </>
+      );
+    }
+  }
+
+  if (
+    event.app === "boostpatriots.win" &&
+    event.author === "18h6yhKBBqXQge6XRauMTeEaQ9HF4jR1qV"
+  ) {
+    return (
+      <>
+        <h3>
+          <a
+            rel="noreferrer"
+            href={`https://boostpatriots.win${event.content.href}`}
+          >
+            BoostPatriots.Win
+          </a>
+        </h3>
+        <h4>{event.content.title}</h4>
+      </>
+    );
+  }
+
+  if (event.app === "powco.dev" && event.type === "github.issue") {
+    return <PowcoDevIssue event={event} />;
+  }
+
+  if (event.type === "url") {
+    if (event.content.url.match("https://gist.github.com")) {
+      const id = event.content.url.split("/").pop();
+
+      return (
+        <>
+          <small className="">
+            <a href="{event.content.html_url}" className="blankLink">
+              {event.content.url}
+            </a>
+          </small>
+          <div className="text-ellipsis ">
+            <Gist id={id} />
+          </div>
+        </>
+      );
+    }
+
+    const url = event.content.url || event.content;
+
+    // 1. check if url is youtube
+    const youtubeLinkRegex =
+      /^(?:https?:\/\/)?(?:www\.)?(?:m\.)?(?:youtu\.be\/|youtube\.com\/(?:embed\/|v\/|watch\?v=|watch\?.+&v=))((\w|-){11})(?:\S+)?$/;
+
+    const youtubeMatch = youtubeLinkRegex.exec(url);
+    if (youtubeMatch) {
+      // 2. get the youtube video id
+      const videoId = youtubeMatch[1];
+      return <YouTube videoId={videoId} opts={youtubePlayerOpts} />;
+    } else {
+      return (
+        <>
+          <LinkPreview
+            url={url}
+            fetcher={customFetcher}
+            showLoader
+            showPlaceholderIfNoImage
+            fallback={
+              <>
+                <a
+                  onClick={(e: any) => e.stopPropagation()}
+                  target="_blank"
+                  rel="noreferrer"
+                  href={url}
+                  className="cursor-pointer text-ellipsis break-words text-blue-500 hover:underline"
+                >
+                  {url}
+                </a>
+              </>
+            }
+          />
+        </>
+      );
+    }
+  }
+
+  return <></>;
+}

--- a/utils/relayX.ts
+++ b/utils/relayX.ts
@@ -1,0 +1,35 @@
+/**
+ * Checks if the input is a string in the format of a RelayX Marketplace location such as: '99ad93845250b23859eceae8f5ca2e8ce953654c0b94b64e890f9c117c1233a6_o2'.
+ * @param input - The input to be checked.
+ * @returns The original input string if it is in the correct format, otherwise null.
+ */
+export function isRelayX(
+  input: any
+): { marketLocation: string; itemLocation: string | null } | null {
+  // Check if input is a string
+  if (typeof input !== "string") {
+    return null;
+  }
+
+  const isRelayXMarketLocation = input.startsWith("https://relayx.com/market/");
+  const isRelayXItem = input.startsWith("https://relayx.com/assets/");
+
+  if (isRelayXMarketLocation) {
+    return {
+      marketLocation: input.substring(input.lastIndexOf("/") + 1),
+      itemLocation: null,
+    };
+  } else if (isRelayXItem) {
+    const assetsIndex = input.indexOf("assets/") + 7;
+    const marketIndex = input.indexOf("/", assetsIndex);
+    const relayXMarketLocation = input.substring(assetsIndex, marketIndex);
+    const relayXItemLocation = input.substring(marketIndex + 1);
+    return {
+      marketLocation: relayXMarketLocation,
+      itemLocation: relayXItemLocation,
+    };
+  } else {
+    return null;
+  }
+}
+


### PR DESCRIPTION
Added a helper function that is used to determine if an item is a RelayX Market link or RelayX Item link.  

The original implementation was incorrectly calling `staging-backend.relayx...` even for non-RelayX links which was leading to a lot of errors in the console. 

More work to be done in the NFTCard and NFTItemCard components (styling + functionality) but those should now appear correctly as well. 